### PR TITLE
Removed dependance on the 44k slick.js file for screenshot slider

### DIFF
--- a/src/app-details.html
+++ b/src/app-details.html
@@ -49,16 +49,17 @@
       </div>
     </div>
     <main class="text-xs-center">
-
+    <div class="card subsection card-inverse text-xs-left p-1">
       <div class="screenshots">
-        <div><img src="https://assets.getpebble.com/api/file/DldSOh50Q6u3wizbbkuh/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div><img src="https://assets.getpebble.com/api/file/Wg9B2VfHSZecpH12rGBc/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div><img src="https://assets.getpebble.com/api/file/iZ2JfX8ERDq7RosEBLDp/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div><img src="https://assets.getpebble.com/api/file/ZehJwnicQjmPRHcoAWzn/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/DldSOh50Q6u3wizbbkuh/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/Wg9B2VfHSZecpH12rGBc/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/iZ2JfX8ERDq7RosEBLDp/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/ZehJwnicQjmPRHcoAWzn/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
+        <br/>
       </div>
-      
+    </div>
       <div class="card subsection text-xs-left p-1 app-details">
         <h1>Description</h1> <hr>
         <pre class="description">Snowy is the most popular personal assistant for Pebble Time. Set reminders, translate sentences, control your home through IFTTT - you name it, and chances are Snowy can help you out.
@@ -119,35 +120,5 @@ Tags: Siri, Cortana, Google Now, Personal Assistant, Voice, Dog, pmkey.xyz</pre>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
-
-    <script type="text/javascript" src="js/slick.min.js"></script>
-     <script type="text/javascript">
-      $(document).ready(function(){
-        $('.screenshots').slick({
-          slidesToScroll: 1,
-          arrows: false,
-          focusOnSelect: true,
-          infinite: false,
-          mobileFirst: true,
-          responsive: [
-            {
-              breakpoint: 600,
-              settings: {
-                slidesToShow: 3,
-                centerMode: true
-              }
-            },
-            {
-              breakpoint: 560,
-              settings: {
-                slidesToShow: 3,
-                centerMode: false
-              }
-            }
-
-          ]
-        });
-      });
-    </script>
   </body>
 </html>

--- a/src/css/.gitignore
+++ b/src/css/.gitignore
@@ -1,0 +1,2 @@
+#We're using SASS. Don't keep the vestigial CSS files, shouldn't be edited anyways.
+*.css

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -198,10 +198,13 @@ main.apps {
 }
 
 .screenshots {
-    margin-bottom: 40px;
+    max-width: 100%;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    display: flex;
     img {
-        margin-left: auto;
-        margin-right: auto;
+        margin-left: 10px;
+        margin-right: 10px;
     }
 }
 


### PR DESCRIPTION
Replaced slick.js with a flexbox and `overflow-x: scroll`. Saved 44K/page load in JS.

I'm no designer, but it required minimal SCSS changes and should be easy enough to modify however you'd like it to end up looking.