### PR TITLE
Moved all SVG's to external files

### DIFF
--- a/src/components/pages/AppDetails.vue
+++ b/src/components/pages/AppDetails.vue
@@ -14,24 +14,16 @@
 
       <div class="app-button-container float-xs-right">
         <button type="button" class="btn btn-outline-secondary btn-thumbs-up">
-        <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <defs></defs>
-          <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-            <g id="Thumbs-Up" stroke="#ccc">
-              <g id="Group-2" transform="translate(-2.000000, -1.000000)">
-                <polygon id="Shape" stroke-width="2" fill="#333" transform="translate(13.706165, 14.531948) rotate(-20.000000) translate(-13.706165, -14.531948) " points="6.26937988 9.97087704 14.2014901 9.72140511 17.1909819 6.1887192 18.0460322 3.83948765 20.6960585 4.80401834 21.0011683 7.04342478 18.1039058 11.9258993 23.6431465 13.942018 23.951116 15.6223717 22.4730776 17.1567559 22.7720466 18.8618384 21.375013 20.1736638 19.9265633 21.9988642 17.6638836 24.9839524 14.8319063 25.2244086 10.7970698 23.7558482 5.76280729 19.9802026 3.46121449 17.686248"></polygon>
-                <path d="M22.5,14.5 L15.5,14.5" id="Line" stroke-linecap="square"></path>
-                <polyline id="Line" stroke-linecap="square" points="16.5 11 14.5 12.5 15.5 14.5 14.5 15.5 14.5 17 14 19 14.5 20.5 14 21.5 14.5 23.5"></polyline>
-                <path d="M15,17.5 L21.5,17.5" id="Line" stroke-linecap="square"></path>
-                <path d="M14.5,20.5 L20.5,20.5" id="Line" stroke-linecap="square"></path>
-              </g>
-            </g>
-          </g>
+        <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1">
+          <use xlink:href="./static/svg/thumbs-up.svg#svgThumbsUp"></use>
         </svg>
+
         2.3K
         </button>
         <a href="pebble://appstore/57ef907a05e4b17e1c000186" class="btn btn-outline-pebble btn-download">
-        <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><rect id="path-1" x="2" y="16" width="21" height="8"></rect><mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="21" height="8" fill="white"><use xlink:href="#path-1"></use></mask><polygon id="path-3" points="11 3 14 3 14 11 18 11 12.5 18 7 11 11 11"></polygon><mask id="mask-4" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-2" y="-2" width="15" height="19"><rect x="5" y="1" width="15" height="19" fill="white"></rect><use xlink:href="#path-3" fill="black"></use></mask><rect id="path-5" x="18" y="19" width="2" height="2"></rect><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="2" height="2" fill="white"><use xlink:href="#path-5"></use></mask></defs><g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Download"><use id="Rectangle-10" stroke="#ff4700" mask="url(#mask-2)" stroke-width="4" fill="#333" xlink:href="#path-1"></use><g id="Rectangle-8"><use id="use1" fill="#333" fill-rule="evenodd" xlink:href="#path-3"></use><use id="use2" stroke="#ff4700" mask="url(#mask-4)" stroke-width="4" xlink:href="#path-3"></use></g><use id="Rectangle-11" stroke="#ff4700" mask="url(#mask-6)" stroke-width="2" fill="#D8D8D8" xlink:href="#path-5"></use></g></g></svg>
+        <svg width="25px" height="25px" viewBox="0 0 25 25">
+          <use xlink:href="./static/svg/download.svg#Download"></use>
+        </svg>
         GET
         </a>
       </div>

--- a/src/components/pages/AppVersions.vue
+++ b/src/components/pages/AppVersions.vue
@@ -14,24 +14,15 @@
 
       <div class="app-button-container float-xs-right">
         <button type="button" class="btn btn-outline-secondary btn-thumbs-up">
-          <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs></defs>
-            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-              <g id="Thumbs-Up" stroke="#ccc">
-                <g id="Group-2" transform="translate(-2.000000, -1.000000)">
-                  <polygon id="Shape" stroke-width="2" fill="#333" transform="translate(13.706165, 14.531948) rotate(-20.000000) translate(-13.706165, -14.531948) " points="6.26937988 9.97087704 14.2014901 9.72140511 17.1909819 6.1887192 18.0460322 3.83948765 20.6960585 4.80401834 21.0011683 7.04342478 18.1039058 11.9258993 23.6431465 13.942018 23.951116 15.6223717 22.4730776 17.1567559 22.7720466 18.8618384 21.375013 20.1736638 19.9265633 21.9988642 17.6638836 24.9839524 14.8319063 25.2244086 10.7970698 23.7558482 5.76280729 19.9802026 3.46121449 17.686248"></polygon>
-                  <path d="M22.5,14.5 L15.5,14.5" id="Line" stroke-linecap="square"></path>
-                  <polyline id="Line" stroke-linecap="square" points="16.5 11 14.5 12.5 15.5 14.5 14.5 15.5 14.5 17 14 19 14.5 20.5 14 21.5 14.5 23.5"></polyline>
-                  <path d="M15,17.5 L21.5,17.5" id="Line" stroke-linecap="square"></path>
-                  <path d="M14.5,20.5 L20.5,20.5" id="Line" stroke-linecap="square"></path>
-                </g>
-              </g>
-            </g>
+          <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1">
+            <use xlink:href="./static/svg/thumbs-up.svg#svgThumbsUp"></use>
           </svg>
           2.3K
         </button>
         <a href="pebble://appstore/57ef907a05e4b17e1c000186" class="btn btn-outline-pebble btn-download">
-          <svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><rect id="path-1" x="2" y="16" width="21" height="8"></rect><mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="21" height="8" fill="white"><use xlink:href="#path-1"></use></mask><polygon id="path-3" points="11 3 14 3 14 11 18 11 12.5 18 7 11 11 11"></polygon><mask id="mask-4" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-2" y="-2" width="15" height="19"><rect x="5" y="1" width="15" height="19" fill="white"></rect><use xlink:href="#path-3" fill="black"></use></mask><rect id="path-5" x="18" y="19" width="2" height="2"></rect><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="2" height="2" fill="white"><use xlink:href="#path-5"></use></mask></defs><g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Download"><use id="Rectangle-10" stroke="#ff4700" mask="url(#mask-2)" stroke-width="4" fill="#333" xlink:href="#path-1"></use><g id="Rectangle-8"><use id="use1" fill="#333" fill-rule="evenodd" xlink:href="#path-3"></use><use id="use2" stroke="#ff4700" mask="url(#mask-4)" stroke-width="4" xlink:href="#path-3"></use></g><use id="Rectangle-11" stroke="#ff4700" mask="url(#mask-6)" stroke-width="2" fill="#D8D8D8" xlink:href="#path-5"></use></g></g></svg>
+          <svg width="25px" height="25px" viewBox="0 0 25 25">
+            <use xlink:href="./static/svg/download.svg#Download"></use>
+          </svg>
           GET
         </a>
       </div>

--- a/src/components/pages/Error.vue
+++ b/src/components/pages/Error.vue
@@ -6,37 +6,8 @@
 
         <h2>Our pet rock has lost your page, sorry about that</h2>
 
-        <svg class="pet-rock-pebble"xmlns="http://www.w3.org/2000/svg" width="406" height="199" viewBox="0 0 406 199" xmlns:xlink="http://www.w3.org/1999/xlink">
-          <defs>
-            <polygon id="a" points="160.865 162.763 243.499 144.619 257.327 109.929 242.053 72.586 209.66 56.935 180.398 34.881 138.125 29.331 89.961 41.943 58.829 43.073 31.846 60.054 13.107 99.878 36.862 138.39 100.393 158.597"/>
-            <mask id="d" width="244.22" height="133.432" x="0" y="0" fill="white">
-              <use xlink:href="#a"/>
-            </mask>
-            <circle id="b" cx="80.5" cy="114.5" r="9.5"/>
-            <mask id="e" width="19" height="19" x="0" y="0" fill="white">
-              <use xlink:href="#b"/>
-            </mask>
-            <circle id="c" cx="29.5" cy="101.5" r="9.5"/>
-            <mask id="f" width="19" height="19" x="0" y="0" fill="white">
-              <use xlink:href="#c"/>
-            </mask>
-          </defs>
-          <g fill="none" fill-rule="evenodd" transform="translate(-14 3)">
-            <g transform="matrix(-1 0 0 1 271 30)">
-              <use fill="#D8D8D8" stroke="#373A3C" stroke-width="10" mask="url(#d)" transform="rotate(-15 135.217 96.047)" xlink:href="#a"/>
-              <polyline stroke="#373A3C" stroke-width="2" points="21 129.5 60.5 150 118.5 146.5 175 137 236.5 103 253.5 75.5"/>
-              <circle cx="31.5" cy="98.5" r="13.5" fill="#FFFFFF" stroke="#373A3C" stroke-width="2"/>
-              <circle cx="83.5" cy="110.5" r="13.5" fill="#FFFFFF" stroke="#373A3C" stroke-width="2"/>
-              <use fill="#373A3C" stroke="#373A3C" stroke-width="2" mask="url(#e)" xlink:href="#b"/>
-              <use fill="#373A3C" stroke="#373A3C" stroke-width="2" mask="url(#f)" xlink:href="#c"/>
-              <circle cx="86" cy="113" r="2" fill="#FFFFFF"/>
-              <circle cx="34" cy="100" r="2" fill="#FFFFFF"/>
-            </g>
-            <polygon fill="#FFFFFF" stroke="#373A3C" stroke-width="5" points="296.576 0 391.886 0 417 22.464 417 91.623 391.886 111.304 308.5 111.304 282.089 128 282.089 100.5 271 91.623 271 22.464"/>
-            <text fill="#000000" font-family="OpenSans-Light, Open Sans" font-size="44" font-weight="300">
-              <tspan x="307" y="71">404</tspan>
-            </text>
-          </g>
+        <svg class="pet-rock-pebble" width="406" height="199" viewBox="0 0 406 199">
+           <use xlink:href="./static/svg/pet-rock.svg#svgPetRock"></use>
         </svg>
 
         <h4>We're getting the following message {{ 404 }}</h4>

--- a/static/svg/download.svg
+++ b/static/svg/download.svg
@@ -1,0 +1,27 @@
+<svg id="svgDownload" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <rect id="path-1" x="2" y="16" width="21" height="8"></rect>
+    <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="21" height="8" fill="white">
+      <use xlink:href="#path-1"></use>
+    </mask>
+    <polygon id="path-3" points="11 3 14 3 14 11 18 11 12.5 18 7 11 11 11"></polygon>
+    <mask id="mask-4" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-2" y="-2" width="15" height="19">
+      <rect x="5" y="1" width="15" height="19" fill="white"></rect>
+      <use xlink:href="#path-3" fill="black"></use>
+    </mask>
+    <rect id="path-5" x="18" y="19" width="2" height="2"></rect>
+    <mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="2" height="2" fill="white">
+      <use xlink:href="#path-5"></use>
+    </mask>
+  </defs>
+  <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Download">
+      <use id="Rectangle-10" stroke="#ff4700" mask="url(#mask-2)" stroke-width="4" fill="#333" xlink:href="#path-1"></use>
+      <g id="Rectangle-8">
+        <use id="use1" fill="#333" fill-rule="evenodd" xlink:href="#path-3"></use>
+        <use id="use2" stroke="#ff4700" mask="url(#mask-4)" stroke-width="4" xlink:href="#path-3"></use>
+      </g>
+      <use id="Rectangle-11" stroke="#ff4700" mask="url(#mask-6)" stroke-width="2" fill="#D8D8D8" xlink:href="#path-5"></use>
+    </g>
+  </g>
+</svg>

--- a/static/svg/pet-rock.svg
+++ b/static/svg/pet-rock.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg id="svgPetRock" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <polygon id="a" points="160.865 162.763 243.499 144.619 257.327 109.929 242.053 72.586 209.66 56.935 180.398 34.881 138.125 29.331 89.961 41.943 58.829 43.073 31.846 60.054 13.107 99.878 36.862 138.39 100.393 158.597"/>
+    <mask id="d" width="244.22" height="133.432" x="0" y="0" fill="white">
+      <use xlink:href="#a"/>
+    </mask>
+    <circle id="b" cx="80.5" cy="114.5" r="9.5"/>
+    <mask id="e" width="19" height="19" x="0" y="0" fill="white">
+      <use xlink:href="#b"/>
+    </mask>
+    <circle id="c" cx="29.5" cy="101.5" r="9.5"/>
+    <mask id="f" width="19" height="19" x="0" y="0" fill="white">
+      <use xlink:href="#c"/>
+    </mask>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(-14 3)">
+    <g transform="matrix(-1 0 0 1 271 30)">
+      <use fill="#D8D8D8" stroke="#373A3C" stroke-width="10" mask="url(#d)" transform="rotate(-15 135.217 96.047)" xlink:href="#a"/>
+      <polyline stroke="#373A3C" stroke-width="2" points="21 129.5 60.5 150 118.5 146.5 175 137 236.5 103 253.5 75.5"/>
+      <circle cx="31.5" cy="98.5" r="13.5" fill="#FFFFFF" stroke="#373A3C" stroke-width="2"/>
+      <circle cx="83.5" cy="110.5" r="13.5" fill="#FFFFFF" stroke="#373A3C" stroke-width="2"/>
+      <use fill="#373A3C" stroke="#373A3C" stroke-width="2" mask="url(#e)" xlink:href="#b"/>
+      <use fill="#373A3C" stroke="#373A3C" stroke-width="2" mask="url(#f)" xlink:href="#c"/>
+      <circle cx="86" cy="113" r="2" fill="#FFFFFF"/>
+      <circle cx="34" cy="100" r="2" fill="#FFFFFF"/>
+    </g>
+    <polygon fill="#FFFFFF" stroke="#373A3C" stroke-width="5" points="296.576 0 391.886 0 417 22.464 417 91.623 391.886 111.304 308.5 111.304 282.089 128 282.089 100.5 271 91.623 271 22.464"/>
+    <text fill="#000000" font-family="OpenSans-Light, Open Sans" font-size="44" font-weight="300">
+      <tspan x="307" y="71">404</tspan>
+    </text>
+  </g>
+</svg>

--- a/static/svg/thumbs-up.svg
+++ b/static/svg/thumbs-up.svg
@@ -1,0 +1,14 @@
+<svg id="svgThumbsUp" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs></defs>
+  <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Thumbs-Up" stroke="#ccc">
+      <g id="Group-2" transform="translate(-2.000000, -1.000000)">
+        <polygon id="Shape" stroke-width="2" fill="#333" transform="translate(13.706165, 14.531948) rotate(-20.000000) translate(-13.706165, -14.531948) " points="6.26937988 9.97087704 14.2014901 9.72140511 17.1909819 6.1887192 18.0460322 3.83948765 20.6960585 4.80401834 21.0011683 7.04342478 18.1039058 11.9258993 23.6431465 13.942018 23.951116 15.6223717 22.4730776 17.1567559 22.7720466 18.8618384 21.375013 20.1736638 19.9265633 21.9988642 17.6638836 24.9839524 14.8319063 25.2244086 10.7970698 23.7558482 5.76280729 19.9802026 3.46121449 17.686248"></polygon>
+        <path d="M22.5,14.5 L15.5,14.5" id="Line" stroke-linecap="square"></path>
+        <polyline id="Line" stroke-linecap="square" points="16.5 11 14.5 12.5 15.5 14.5 14.5 15.5 14.5 17 14 19 14.5 20.5 14 21.5 14.5 23.5"></polyline>
+        <path d="M15,17.5 L21.5,17.5" id="Line" stroke-linecap="square"></path>
+        <path d="M14.5,20.5 L20.5,20.5" id="Line" stroke-linecap="square"></path>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The download, pet rock, and thumbs up SVG's are now saved in external files. This reduces code duplication and permits browser caching.

Additionally, this has (magically) resolved the issue with Chrome barfing on the download icon! :tada: 

![image](https://cloud.githubusercontent.com/assets/3112763/21432943/d80d268a-c83b-11e6-9650-e4642b4f408b.png)
