### PR TITLE
Added WSL dependency and cleaned up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ npm run e2e
 npm test
 ```
 
+## Installing Dev Environment On Windows 10
+First make sure you have [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) installed and enabled.
 
-## Installing Dev Environment On Windows
-1. Make sure you have [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) installed.
-2. Run Ubuntu installation steps.
-3. Try running it with `npm run dev`. If it fails to find `node-sass/vendor` rebuild it `npm rebuild node-sass`.
+Try running `npm run dev`. If it fails to find `node-sass/vendor` the package must be rebuilt. This can be done with `npm rebuild node-sass`.
 
-A patched version of the node-macaddress package is included in the devDependencies section of the package.json to make the webpack dev environment work inside WSL. The patched package can be found [here](https://github.com/TheBeastOfCaerbannog/node-macaddress#43238cd0569573837d4b48a27b3063d287d2968b), and more information on the bug that requires it can be found [here](https://github.com/AngularClass/angular2-webpack-starter/issues/1273).
+A patched version of the `node-macaddress` package is included in the `devDependencies` section of the `package.json` to make the webpack dev environment work inside WSL. The patched package can be found [here](https://github.com/TheBeastOfCaerbannog/node-macaddress#43238cd0569573837d4b48a27b3063d287d2968b), and more information on the bug that requires it can be found [here](https://github.com/AngularClass/angular2-webpack-starter/issues/1273).

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ For detailed explanation on how things work, checkout the [guide](http://vuejs-t
 
 
 ## Installing Dev Environment On Windows
-
 1. Make sure you have  [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) installed.
 2. Run Ubuntu installation steps.
-3. Install node-macaddress (this version only): `npm install github:TheBeastOfCaerbannog/node-macaddress.git#43238cd0569573837d4b48a27b3063d287d2968b`
-4. Try running it with `npm run dev`. If it fails to find `node-sass/vendor` rebuild it `npm rebuild node-sass`.
+3. Try running it with `npm run dev`. If it fails to find `node-sass/vendor` rebuild it `npm rebuild node-sass`.
+
+A patched version of the node-macaddress package is included in the devDependencies section of the package.json to make the webpack dev environment work inside WSL. The patched package can be found [here](https://github.com/TheBeastOfCaerbannog/node-macaddress#43238cd0569573837d4b48a27b3063d287d2968b), and more information on the bug that requires it can be found [here](https://github.com/AngularClass/angular2-webpack-starter/issues/1273).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # rebble-app-store
 
-## THIS REPO IS UNDER ACTIVE DEVELOPMENT, EVERYTHING IS SUBJECT TO CHANGE!
+This is the Rebble replacement for the Pebble app store. This project is under active development, though the eventual goal is to reach feature parity with the current Pebble smartwatch app store.
 
-> Rebble.io Appstore
+This project is built with [VueJS 2](https://vuejs.org/), with webpack scripts included for debugging, hot-reload, and production builds. More information on the Vue webpack build scripts can be found [here](https://github.com/vuejs-templates/webpack).
 
-## Build Setup
+## Installing
 
 ``` bash
 # install dependencies
@@ -26,11 +26,9 @@ npm run e2e
 npm test
 ```
 
-For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
-
 
 ## Installing Dev Environment On Windows
-1. Make sure you have  [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) installed.
+1. Make sure you have [WSL](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) installed.
 2. Run Ubuntu installation steps.
 3. Try running it with `npm run dev`. If it fails to find `node-sass/vendor` rebuild it `npm rebuild node-sass`.
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lolex": "^1.4.0",
     "mocha": "^3.1.0",
     "nightwatch": "^0.9.8",
+    "node-macaddress": "git@github.com:TheBeastOfCaerbannog/node-macaddress.git#43238cd0569573837d4b48a27b3063d287d2968b",
     "node-sass": "^4.1.1",
     "opn": "^4.0.2",
     "ora": "^0.3.0",


### PR DESCRIPTION
The patched version of node-macadress has been added to the devDepencies. Updated documentation on README and cleaned up wording.