### PR TITLE
Implemented some backend endpoints

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -160,6 +160,7 @@ ul.pagination {
          .page-link {
             // Change text colot
             color: $pebble-color;
+            cursor: pointer;
             &:hover, &:focus  {
                 // Overwrite hover and focus states
                 text-decoration: none;

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <div class="flex-content">
       <svg-container></svg-container>
       <navbar></navbar>
-      <router-view></router-view>
+      <router-view v-bind:backendUrl="backendUrl"></router-view>
     </div>
     <page-footer></page-footer>
   </div>
@@ -22,6 +22,11 @@ export default {
     Navbar,
     Home,
     PageFooter
+  },
+  data: function () {
+    return {
+      backendUrl: 'http://localhost:8080'
+    }
   }
 }
 </script>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -2,8 +2,8 @@
   <div>
     <slider></slider>
     <main class="apps container text-center">
-      <card-collection elTitle="Most Recent"></card-collection>
-      <card-collection elTitle="Fresh Picks"></card-collection>
+      <card-collection elTitle="Most Recent" v-bind:cards="mostRecentCards"></card-collection>
+      <card-collection elTitle="Fresh Picks" v-bind:cards="freshPicksCards"></card-collection>
     </main>
   </div>
 </template>
@@ -12,11 +12,192 @@
 import CardCollection from './pages/widgets/CardCollection'
 import Slider from './Slider'
 
+// mostRecentCards and freshPicksCards are placeholders. Todo: actually fetch those from the server.
 export default {
   name: 'Home',
   components: {
     CardCollection,
     Slider
+  },
+  data: function () {
+    return {
+      mostRecentCards: {
+        'cards': [
+          {
+            'id': '52cc44e045ffdd31dd000180',
+            'title': 'YWeather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/Ns6eOrYKQqmYBKOamabV/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 19933
+          },
+          {
+            'id': '533966299820be90ed0000c5',
+            'title': 'Real Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/3nTAsboHTVmxRcR96hcK/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 13413
+          },
+          {
+            'id': '53381b17d1719b42b800028b',
+            'title': 'Weather Land',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/7ZQwPhFzRnOon0lC154m/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 8337
+          },
+          {
+            'id': '52d313a912ea3dcf84000024',
+            'title': 'Futura Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/GtpiSE2SpWyO5Xytsuz1/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 5256
+          },
+          {
+            'id': '53d9650e4b87266dc9000082',
+            'title': 'Weather - powered by The Weather Channel',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/nL8Rpn0Sr2xPvqnX0XVc/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 4609
+          },
+          {
+            'id': '535cf7f618c570bf05000023',
+            'title': 'Love Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/wUP4KTqgTmqoyIHsR6k8/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 4194
+          },
+          {
+            'id': '54f791b593d5fbffb1000090',
+            'title': 'Sketchy Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/1f1P4aoYTJm5pifableO/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 3439
+          },
+          {
+            'id': '547bd7a0fb079720950000a7',
+            'title': 'Minimalist Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/pGyFR0W9QWiVrrCzFKhZ/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2988
+          },
+          {
+            'id': '52dca032f9d8ec5031000068',
+            'title': 'Time\u0026Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/WoICJjzdQHSzfuxDdQVO/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2356
+          },
+          {
+            'id': '5599a73fe47bb388a7000056',
+            'title': 'Simple Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/RXAUoSIaRpq3tj3hwGnU/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2019
+          },
+          {
+            'id': '529eaee7d7894b8324000022',
+            'title': 'Weather',
+            'type': 'watchapp',
+            'image_url': 'https://assets.getpebble.com/api/file/TKQb98tDSJeO83j3oXbK/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1950
+          },
+          {
+            'id': '566dc3ab7929075b2e000042',
+            'title': 'WUnderful Analog (Weather)',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/U10bXt0DSfusEGiBKgcl/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1796
+          }
+        ]
+      },
+      freshPicksCards: {
+        'cards': [
+          {
+            'id': '566dc3ab7929075b2e000042',
+            'title': 'WUnderful Analog (Weather)',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/U10bXt0DSfusEGiBKgcl/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1796
+          },
+          {
+            'id': '555147c5095d4f7c75000087',
+            'title': ' Analog Hodinky',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/NPfJzg9FQ4ORvkvPE3qN/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1059
+          },
+          {
+            'id': '555a3c55c2afa2329c000006',
+            'title': 'Simple Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/EU9YQpETSSWzHV2kdx7o/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 647
+          },
+          {
+            'id': '56128b0799362a9a5500009b',
+            'title': 'Analog by Dalpek',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/gTZD9ONLRGBiGHWDG8dI/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 642
+          },
+          {
+            'id': '55a7f437e2c6fed89b000055',
+            'title': 'TimeFace One (Analog)',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/9CWVMOEOSQGsip7ANKKg/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 471
+          },
+          {
+            'id': '564b100fe4ec39504000000b',
+            'title': 'Very Simple Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/K3osEgGEQEywL9JhVktL/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 369
+          },
+          {
+            'id': '567875eed3e05b0b56000046',
+            'title': 'Classic Analogue',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/xan9O8dFQzKpqE8XNF3a/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 347
+          },
+          {
+            'id': '52f2107ae21be4b82000117d',
+            'title': 'Fuzzy Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/Cog2VxluTiKfQgE80oxt/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 346
+          },
+          {
+            'id': '568ec32dfc66e37c3000006c',
+            'title': 'AWW1 - Analog WeatherWatch',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/VqDC7IF7QWyYvOeJVO80/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 300
+          },
+          {
+            'id': '555e112c0981804be000000c',
+            'title': 'Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/bT4zrDkeSDq5zvAygBnm/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 295
+          },
+          {
+            'id': '57cb6526be5ad0f2d800022b',
+            'title': 'Day/Night Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/JdGlMbBQJyiqtpgL5LBg/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 186
+          },
+          {
+            'id': '56263a92763f6c66c0000057',
+            'title': 'Simpler Analog',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/68UF1XZzSymNPtOamcWJ/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 184
+          }
+        ]
+      }
+    }
   }
 }
 </script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -15,9 +15,14 @@
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#categorySelector" aria-controls="categorySelector" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <a class="search" href="#/search">
+        <a class="search" href="/search">
           <svg class="icon-search" width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <use xlink:href="#iconSearch"></use>
+          </svg>
+        </a>
+        <a class="settings" href="/settings">
+          <svg class="icon-settings" width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <use xlink:href="#iconSettings"></use>
           </svg>
         </a>
       </div>
@@ -25,14 +30,14 @@
     <div class="collapse text-center" id="categorySelector">
       <div class="text-muted p-1">
         <div class="btn-group btn-group-lg" role="group">
-          <a href="#/" v-bind:class="{ active: currentRoute == '/'}" class="btn btn-outline-secondary btn-watchface" role="button">
+          <a href="/" v-bind:class="{ active: currentRoute == '/'}" class="btn btn-outline-secondary btn-watchface" role="button">
             <svg class="icon-watchface" width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <use xlink:href="#iconWatchface"></use>
             </svg>
             Watchfaces
           </a>
 
-          <a href="#/apps" v-bind:class="{ active: currentRoute == '/apps'}" class="btn btn-outline-secondary btn-app" role="button">
+          <a href="/apps" v-bind:class="{ active: currentRoute == '/apps'}" class="btn btn-outline-secondary btn-app" role="button">
             <svg class="icon-app" width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <use xlink:href="#iconApp"></use>
             </svg>
@@ -114,6 +119,11 @@ export default {
             // Search Icon
             a.search {
               padding-top: 5px; // Move it down
+            }
+
+            // Settings Icon
+            a.settings {
+              padding-top: 5px;
             }
 
             // Hamburger icon

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -7,9 +7,9 @@
         <li data-target="#featured-carousel" data-slide-to="2"></li>
       </ol>
       <div class="carousel-inner" role="listbox">
-        <div class="carousel-item active"><a href="#/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/mzxYxZmWTbSSyDBG6spA/convert?cache=true&fit=crop&w=720&h=320" alt="First slide"></a></div>
-        <div class="carousel-item"><a href="#/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/kionqG5sSACzS3au4yZo/convert?cache=true&fit=crop&w=720&h=320" alt="Second slide"></a></div>
-        <div class="carousel-item"><a href="#/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/3HYkoCo7SzIaEyYlizBA/convert?cache=true&fit=crop&w=720&h=320" alt="Third slide"></a></div>
+        <div class="carousel-item active"><a href="/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/mzxYxZmWTbSSyDBG6spA/convert?cache=true&fit=crop&w=720&h=320" alt="First slide"></a></div>
+        <div class="carousel-item"><a href="/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/kionqG5sSACzS3au4yZo/convert?cache=true&fit=crop&w=720&h=320" alt="Second slide"></a></div>
+        <div class="carousel-item"><a href="/featured"><img class="d-block img-fluid" src="https:/assets.getpebble.com/api/file/3HYkoCo7SzIaEyYlizBA/convert?cache=true&fit=crop&w=720&h=320" alt="Third slide"></a></div>
       </div>
       <a class="carousel-control carousel-control-prev" href="#featured-carousel" role="button" data-slide="prev">
         <i class="fa fa-angle-left" aria-hidden="true"></i>

--- a/src/components/SvgContainer.vue
+++ b/src/components/SvgContainer.vue
@@ -65,6 +65,25 @@
           </g>
         </svg>
 
+    <svg id="iconSettings" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <g fill="none" fill-rule="evenodd">
+            <circle r="7" cx="12.5" cy="12.5" stroke-width="4"/>
+            <!-- bottom -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5"/>
+            <!-- top -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5" transform="rotate(180 12.5 12.5)"/>
+            <!-- left bottom -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5" transform="rotate(60 12.5 12.5)"/>
+            <!-- left top -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5" transform="rotate(120 12.5 12.5)"/>
+            <!-- right bottom -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5" transform="rotate(-60 12.5 12.5)"/>
+            <!-- right top -->
+            <polygon stroke-width="4" points="10.5,19.5 14.5,19.5 14,21.5 11,21.5" transform="rotate(-120 12.5 12.5)"/>
+            <!-- <polygon stroke-width="4" points="9,4.4 16,4.4 15.5,0.5 9.5,0.5"/> -->
+          </g>
+        </svg>
+
 
     <symbol id="iconApp" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
       <g fill="none" fill-rule="evenodd" stroke="#000000" stroke-width="2" transform="translate(1 1)">
@@ -106,6 +125,11 @@ export default {
     stroke: #9b9d9e;
     // This should be the color but the overlapping paths make it not ideal because it is 50% translucent
     // stroke: rgba(255, 255, 255, 0.5);
+  }
+
+  .icon-settings {
+      fill: transparent;
+      stroke: #9b9d9e;
   }
 
   .btn-watchface svg, .btn-app svg {

--- a/src/components/pages/AppDetails.vue
+++ b/src/components/pages/AppDetails.vue
@@ -22,7 +22,7 @@
           <tr>
             <td>Tags</td>
             <td v-for="tag in app.appInfo.tags">
-              <a href="#"><span class="badge badge-pill badge-pebble">{{ tag.name }}</span></a>
+              <a v-bind:href="'/collection/' + tag.id"><span class="badge badge-pill badge-pebble">{{ tag.name }}</span></a>
             </td>
           </tr>
           <tr>

--- a/src/components/pages/AppDetails.vue
+++ b/src/components/pages/AppDetails.vue
@@ -2,107 +2,62 @@
   <section>
     <header>
       <div class="app-banner">
-        <img src="https://assets.getpebble.com/api/file/qaQdjUUrSOq0psR1XHDp/convert?cache=true&fit=crop&w=720&h=320" alt="App Banner">
+        <img v-if="app.assets.appBanner != ''" v-bind:src="app.assets.appBanner" alt="App Banner">
       </div>
     </header>
-    <div class="card subsection-inverse card-inverse text-left p-3 app-title-bar">
-      <img class="app-icon" src="https://assets.getpebble.com/api/file/9AfKJDBBS72iAYR4WpgK/convert?cache=true&fit=crop&w=48&h=48" alt="My App">
-      <div class="title-author">
-        <h1 class="tile">Snowy</h1>
-        <h2 class="author">Mathew Reiss</h2>
-      </div>
-
-      <div class="app-button-container float-right">
-        <button type="button" class="btn btn-outline-secondary btn-thumbs-up">
-        <svg class="svg-icon icon-thumbs-up" width="25px" height="25px" viewBox="0 0 25 25">
-          <use xlink:href="#iconThumbsUp"></use>
-        </svg>
-
-        2.3K
-        </button>
-        <a href="pebble://appstore/57ef907a05e4b17e1c000186" class="btn btn-outline-pebble btn-download">
-        <svg class="svg-icon icon-download" width="25px" height="25px" viewBox="0 0 25 25">
-          <use xlink:href="#iconDownload"></use>
-        </svg>
-        GET
-        </a>
-      </div>
-    </div>
+    <app-title-bar v-bind:app="app"></app-title-bar>
 
     <main class="text-center">
-      <div class="screenshots dragscroll">
-        <div class="screenshot-spacer"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/DldSOh50Q6u3wizbbkuh/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/Wg9B2VfHSZecpH12rGBc/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/iZ2JfX8ERDq7RosEBLDp/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/ZehJwnicQjmPRHcoAWzn/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot"><img src="https://assets.getpebble.com/api/file/tfA108w2QBiqT3YIBbdY/convert?cache=true&fit=crop&w=144&h=168" alt="screenshot"></div>
-        <div class="screenshot-spacer"></div>
-      </div>
+      <screenshot-list v-bind:platforms="app.assets.screenshots" v-bind:clientPlatform="clientPlatform"></screenshot-list>
 
       <div class="card subsection text-left p-3 app-details">
         <h1>Description</h1> <hr>
-        <pre class="description">Snowy is the most popular personal assistant for Pebble Time. Set reminders, translate sentences, control your home through IFTTT - you name it, and chances are Snowy can help you out.
-
-        For just $2.99 through KiezelPay, you can have the app voted "Most Creative Project" at the 2015 Pebble Developer Retreat, and one of Eric Migicovsky's (Founder and CEO of Pebble) favorite apps! Download Snowy and follow the onscreen instructions for obtaining a license. No companion app, no hassle, all awesome.
-
-        The Pebble smartwatch just got a little smarter...
-
-        ---
-
-        For more information, visit MyDogSnowy.com, and if you love Snowy, remember to give him a ❤️!
-
-        ===
-
-        DANSK (Beta): mydogsnowy.com/da
-
-        DEUTSCH: mydogsnowy.com/de
-
-        ESPAÑOL: mydogsnowy.com/es
-
-        FRANÇAIS: mydogsnowy.com/fr
-
-        ITALIANO: mydogsnowy.com/it
-
-        PORTUGUÊS (Beta): mydogsnowy.com/pt
-
-        badges: Siri, Cortana, Google Now, Personal Assistant, Voice, Dog, pmkey.xyz</pre>
+        <pre class="description">{{ app.description }}</pre>
 
         <table class="extra-table">
           <tr>
             <td>Developer</td>
-            <td>Mathew Reiss</td>
+            <td>{{ app.author.name }}</td>
           </tr>
           <tr>
             <td>Tags</td>
-            <td><a href="#"><span class="badge badge-pill badge-pebble">Tools & Utilities</span></a></td>
+            <td v-for="tag in app.appInfo.tags">
+              <a href="#"><span class="badge badge-pill badge-pebble">{{ tag.name }}</span></a>
+            </td>
           </tr>
           <tr>
             <td>Updated</td>
-            <td>Dec 7, 2016</td>
+            <td>{{ app.appInfo.updated | formatDate }}</td>
           </tr>
           <tr>
             <td>Version</td>
-            <td>4.4</td>
+            <td>{{ app.appInfo.version }}</td>
           </tr>
         </table>
-        <a href="#/app-versions" class="app-button">
+        <a v-bind:href="'/app-versions/' + $route.params.id" class="app-button">
           <div>
-            Version information <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
+            Version Information <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
           </div>
         </a>
-        <a href="#" class="app-button">
+        <a v-if="app.appInfo.authorUrl != ''" v-bind:href="app.appInfo.authorUrl" class="app-button">
           <div>
             Website Link <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
           </div>
         </a>
-        <a href="#" class="app-button">
+        <a v-if="app.appInfo.supportUrl != ''" v-bind:href="app.appInfo.supportUrl" class="app-button">
           <div>Support <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
           </div>
         </a>
-        <a href="#/author" class="app-button">
+        <a v-if="app.appInfo.sourceUrl != ''" v-bind:href="app.appInfo.sourceUrl" class="app-button">
+          <div>Source code <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
+          </div>
+        </a>
+        <a v-bind:href="'/author/' + app.author.id" class="app-button">
           <div>More From This Developer<i class="fa fa-angle-right float-right" aria-hidden="true"></i>
+          </div>
+        </a>
+        <a v-if="app.appInfo.pbwUrl != ''" v-bind:href="app.appInfo.pbwUrl" class="app-button">
+          <div>Download .pbw<i class="fa fa-angle-right float-right" aria-hidden="true"></i>
           </div>
         </a>
       </div>
@@ -111,8 +66,71 @@
 </template>
 
 <script>
+import AppTitleBar from './widgets/AppTitleBar'
+import ScreenshotList from './widgets/ScreenshotList'
+
 export default {
-  name: 'app-details'
+  name: 'app-details',
+  components: {
+    AppTitleBar,
+    ScreenshotList
+  },
+  props: {
+    backendUrl: ''
+  },
+  data: function () {
+    return {
+      app: {
+        'id': '',
+        'title': '',
+        'author': {
+          'id': -1,
+          'name': ''
+        },
+        'description': '',
+        'thumbs_up': 0,
+        'type': '',
+        'supported_platforms': [],
+        'published_date': '2000-01-01T00:00:00.000+00:00',
+        'appInfo': {
+          'pbwUrl': '',
+          'rebbleReady': false,
+          'tags': [],
+          'updated': '2000-01-01T00:00:00.000+00:00',
+          'version': '',
+          'supportUrl': '',
+          'authorUrl': '',
+          'sourceUrl': ''
+        },
+        'assets': {
+          'appBanner': '',
+          'appIcon': '',
+          'screenshots': []
+        },
+        'doomsday_backup': false
+      },
+      clientPlatform: window.localStorage.getItem('platform')
+    }
+  },
+  methods: {
+    get_app: function (id) {
+      var that = this
+      window.$.getJSON(this.backendUrl + '/dev/apps/get_app/id/' + id, function (j, s) {
+        if (s === 'success') {
+          that.app = j
+        } else {
+          console.error(s)
+          console.error(j)
+        }
+      })
+    }
+  },
+  beforeMount: function () {
+    this.get_app(this.$route.params.id)
+    if (this.clientPlatform == null) {
+      this.clientPlatform = 'basalt'
+    }
+  }
 }
 </script>
 
@@ -121,41 +139,6 @@ export default {
 
 // _app-details.scss
 // App details page styles
-
-// Screenshots slider
-.screenshots {
-    max-width: 100%;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    display: flex;
-    margin-bottom: 40px;
-    -ms-overflow-style: none;
-    overflow: -moz-scrollbars-none;
-    &::-webkit-scrollbar {
-        background: transparent;
-        width: 0 !important;
-    }
-    img {
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-        margin-left: 20px;
-        margin-right: 20px;
-        margin-bottom: 5px;
-        margin-top: 5px;
-        user-drag: none;
-        user-select: none;
-        -moz-user-select: none;
-        -webkit-user-drag: none;
-        -webkit-user-select: none;
-        -ms-user-select: none;
-    }
-    // This spacer is the one that centers the first screenshot
-    .screenshot-spacer {
-        width: calc(50vw - 92px);
-        height: 168px;
-        display: table;
-    }
-}
 
 // Similar to carousel but only used when displaying only one image
 .app-banner {
@@ -168,78 +151,6 @@ export default {
       width: 100%;
       max-width: 720px;
   }
-}
-
-// Title bar displayed below app banner
-.app-title-bar {
-    padding-left: 68px !important;
-    img {
-        position: absolute;
-        border-radius: 4px;
-        width: 42px;
-        height: 42px;
-        left: 16px;
-    }
-    // Author name and app title text container
-    .title-author {
-      height: 42px;
-      margin-top: -3px;
-      margin-bottom: 3px;
-      display: inline-block;
-      h1 {
-        font-size: 19px;
-        line-height: 26px;
-        display: inline;
-        color: #fff;
-      }
-      h2 {
-        line-height: 16px;
-        font-size: 16px;
-        color: #c3c3c3;
-        margin: 0;
-      }
-
-      // Styles for small screens
-      @media screen and (max-width: 430px) {
-        h1 {
-          font-size: 15px;
-        }
-        h2 {
-          font-size: 12px;
-        }
-      }
-      @media screen and (max-width: 320px) {
-        h1 {
-          font-size: 12px;
-        }
-        h2 {
-          font-size: 10px;
-        }
-      }
-    }
-
-    // Set styles of buttons in the app-button-container (app-details and app-versions page)
-    .app-button-container {
-      margin-top: 2px;
-      margin-bottom: 2px;
-      .btn {
-        @media screen and (max-width: 430px) {
-          // styles for when screen smaller than 430px to avoid breaking all styles (they make things smaller)
-          margin-top: 3px;
-          font-size: 0.7rem;
-          padding: .5rem .5rem;
-        }
-
-        // Set thumbs up button styles
-        &.btn-thumbs-up {
-          // Styles for when it is in focus, hovered, or active
-          &:hover, &:active, &.active {
-            color: #333;
-            outline: none;
-          }
-        }
-      }
-    }
 }
 
 // App details container (below screenshots)

--- a/src/components/pages/AppVersions.vue
+++ b/src/components/pages/AppVersions.vue
@@ -2,49 +2,92 @@
   <div>
     <header>
       <div class="app-banner">
-        <img src="https://assets.getpebble.com/api/file/qaQdjUUrSOq0psR1XHDp/convert?cache=true&fit=crop&w=720&h=320" alt="App Banner">
-    </div>
+        <img v-if="app.assets.appBanner != ''" v-bind:src="app.assets.appBanner" alt="App Banner">
+      </div>
     </header>
-    <div class="card subsection-inverse card-inverse text-left p-3 app-title-bar">
-      <img class="app-icon" src="https://assets.getpebble.com/api/file/9AfKJDBBS72iAYR4WpgK/convert?cache=true&fit=crop&w=48&h=48" alt="My App">
-      <div class="title-author">
-        <h1 class="tile">Snowy</h1>
-        <h2 class="author">Mathew Reiss</h2>
-      </div>
-
-      <div class="app-button-container float-right">
-        <button type="button" class="btn btn-outline-secondary btn-thumbs-up">
-        <svg class="svg-icon icon-thumbs-up" width="25px" height="25px" viewBox="0 0 25 25">
-          <use xlink:href="#iconThumbsUp"></use>
-        </svg>
-
-        2.3K
-        </button>
-        <a href="pebble://appstore/57ef907a05e4b17e1c000186" class="btn btn-outline-pebble btn-download">
-        <svg class="svg-icon icon-download" width="25px" height="25px" viewBox="0 0 25 25">
-          <use xlink:href="#iconDownload"></use>
-        </svg>
-        GET
-        </a>
-      </div>
-    </div>
+    <app-title-bar v-bind:app="app"></app-title-bar>
 
     <main class="text-center">
-      <div class="card subsection text-left p-3 app-details">
-        <h2>Version 4.4</h2> <h3 class="float-right">Dec 7, 2016</h3><hr>
-        <pre class="description">Pre-apocalyptic release with some new features and bug-fixes (change log coming post-apocalypse). This has been a wild ride y'all. Not sure if anyone even reads these, but it's been an honor and a privilege to work with such a great community over the last few years. Stay awesome, Pebblers.</pre>
-      </div>
-      <div class="card subsection text-left p-3 app-details">
-        <h2>Version 4.3</h2> <h3 class="float-right">Oct 20, 2016</h3><hr>
-        <pre class="description">No information available</pre>
+      <div class="card subsection text-left p-3 app-details" v-for="version in versions.versions">
+        <h2>Version {{ version.number }}</h2> <h3 class="float-right">{{ version.release_date | formatDate }}</h3><hr>
+        <pre class="description">{{ version.description }}</pre>
       </div>
     </main>
   </div>
 </template>
 
 <script>
+import AppTitleBar from './widgets/AppTitleBar'
+
 export default {
-  name: 'app-version'
+  name: 'app-version',
+  components: {
+    AppTitleBar
+  },
+  data: function () {
+    return {
+      app: {
+        'id': '',
+        'title': '',
+        'author': {
+          'id': -1,
+          'name': ''
+        },
+        'description': '',
+        'thumbs_up': 0,
+        'type': '',
+        'supported_platforms': [],
+        'published_date': '2000-01-01T00:00:00.000+00:00',
+        'appInfo': {
+          'pbwUrl': '',
+          'rebbleReady': false,
+          'tags': [],
+          'updated': '2000-01-01T00:00:00.000+00:00',
+          'version': '',
+          'supportUrl': '',
+          'authorUrl': '',
+          'sourceUrl': ''
+        },
+        'assets': {
+          'appBanner': '',
+          'appIcon': '',
+          'screenshots': []
+        },
+        'doomsday_backup': false
+      },
+      versions: {
+        'versions': []
+      }
+    }
+  },
+  methods: {
+    get_versions: function (id) {
+      var that = this
+      window.$.getJSON('http://localhost:8080/dev/apps/get_versions/id/' + id, function (j, s) {
+        if (s === 'success') {
+          that.versions = j
+        } else {
+          console.error(s)
+          console.error(j)
+        }
+      })
+    },
+    get_app: function (id) {
+      var that = this
+      window.$.getJSON('http://localhost:8080/dev/apps/get_app/id/' + id, function (j, s) {
+        if (s === 'success') {
+          that.app = j
+        } else {
+          console.error(s)
+          console.error(j)
+        }
+      })
+    }
+  },
+  beforeMount: function () {
+    this.get_app(this.$route.params.id)
+    this.get_versions(this.$route.params.id)
+  }
 }
 </script>
 

--- a/src/components/pages/Collection.vue
+++ b/src/components/pages/Collection.vue
@@ -1,0 +1,97 @@
+<template>
+  <div>
+    <header>
+      <div class="title-card">
+        <h3>Collection: {{ collection.name }}</h3>
+      </div>
+    </header>
+    <main class="apps container text-center">
+      <form>
+			  <input type="radio" id="sort-new" value="new" v-model="sort"> <label for="sort-new">Sort by New</label><br />
+			  <input type="radio" id="sort-popular" value="popular" v-model="sort"> <label for="sort-popular">Sort by popular</label><br />
+      </form>
+
+      <card-collection :showTop="false" v-bind:cards="collection"></card-collection>
+
+      <nav>
+        <ul class="pagination">
+          <li v-bind:class="'page-item' + (currentPage == 1 ? ' disabled' : '')">
+            <a class="page-link" tabindex="-1" aria-label="Previous" v-on:click="currentPage--">
+              <span aria-hidden="true"><i class="fa fa-angle-left" aria-hidden="true"></i></span>
+              <span class="sr-only">Previous</span>
+            </a>
+          </li>
+          <li v-for="page in collection.pages" v-bind:class="'page-item' + (currentPage == page ? ' active' : '')"><a class="page-link" v-on:click="currentPage = page">{{ page }}</a></li>
+          <li v-bind:class="'page-item' + (currentPage == collection.pages ? ' disabled' : '')">
+            <a class="page-link" aria-label="Next" v-on:click="currentPage++">
+              <span aria-hidden="true"><i class="fa fa-angle-right" aria-hidden="true"></i></span>
+              <span class="sr-only">Next</span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </main>
+  </div>
+</template>
+
+<script>
+import CardCollection from './widgets/CardCollection'
+
+export default {
+  name: 'collection',
+  components: {
+    CardCollection
+  },
+  props: {
+    backendUrl: ''
+  },
+  data: function () {
+    return {
+      collection: {
+        id: '',
+        name: '',
+        pages: 0,
+        cards: []
+      },
+      sort: 'new',
+      currentPage: 1,
+      clientPlatform: window.localStorage.getItem('platform')
+    }
+  },
+  methods: {
+    getCollection: function (id) {
+      var that = this
+
+      // Remove card to provide user input that something has changed while we wait for the backend
+      this.collection.cards = []
+
+      window.$.getJSON(this.backendUrl + '/dev/apps/get_collection/id/' + encodeURIComponent(id) + '?platform=' + this.clientPlatform + '&order=' + this.sort + '&page=' + this.currentPage, function (j, s) {
+        if (s === 'success') {
+          that.collection = j
+        } else {
+          console.error(s)
+          console.error(j)
+        }
+      })
+    }
+  },
+  beforeMount: function () {
+    if (this.clientPlatform == null) {
+      this.clientPlatform = 'basalt'
+    }
+
+    this.getCollection(this.$route.params.id)
+  },
+  watch: {
+    sort: function () {
+      this.getCollection(this.$route.params.id)
+    },
+    currentPage: function () {
+      this.getCollection(this.$route.params.id)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/pages/Collection.vue
+++ b/src/components/pages/Collection.vue
@@ -6,10 +6,15 @@
       </div>
     </header>
     <main class="apps container text-center">
-      <form>
-			  <input type="radio" id="sort-new" value="new" v-model="sort"> <label for="sort-new">Sort by New</label><br />
-			  <input type="radio" id="sort-popular" value="popular" v-model="sort"> <label for="sort-popular">Sort by popular</label><br />
-      </form>
+      <div class="btn-group" role="group">
+        <a v-bind:class="{ active: sort == 'new'}" v-on:click="sort = 'new'" class="btn btn-outline-secondary" role="button">
+          Sort by New
+        </a>
+
+        <a v-bind:class="{ active: sort == 'popular'}" v-on:click="sort = 'popular'" class="btn btn-outline-secondary" role="button">
+          Sort by Popular
+        </a>
+      </div>
 
       <card-collection :showTop="false" v-bind:cards="collection"></card-collection>
 
@@ -94,4 +99,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .btn-group {
+    margin-bottom: 25px;
+  }
 </style>

--- a/src/components/pages/Error.vue
+++ b/src/components/pages/Error.vue
@@ -34,7 +34,7 @@
           <h4>We're getting the following message {{ 404 }}</h4>
           <div class="page-error_buttons">
             <a href="javascript:history.go(0)" class="btn btn-outline-secondary">Try again</a>
-            <a href="/#" class="btn btn-outline-pebble">Back to home</a>
+            <a href="/" class="btn btn-outline-pebble">Back to home</a>
           </div>
         </div>
       </section>

--- a/src/components/pages/Featured.vue
+++ b/src/components/pages/Featured.vue
@@ -6,7 +6,7 @@
       </div>
     </header>
     <main class="apps container text-center">
-      <card-collection :showTop="false"></card-collection>
+      <card-collection :showTop="false" v-bind:cards="featuredCards"></card-collection>
 
       <nav>
         <ul class="pagination">
@@ -38,10 +38,103 @@
 <script>
 import CardCollection from './widgets/CardCollection'
 
+// featuredCards is a placeholder. Todo: actually fetch those from the server.
 export default {
   name: 'featured',
   components: {
     CardCollection
+  },
+  data: function () {
+    return {
+      featuredCards: {
+        'cards': [
+          {
+            'id': '52cc44e045ffdd31dd000180',
+            'title': 'YWeather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/Ns6eOrYKQqmYBKOamabV/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 19933
+          },
+          {
+            'id': '533966299820be90ed0000c5',
+            'title': 'Real Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/3nTAsboHTVmxRcR96hcK/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 13413
+          },
+          {
+            'id': '53381b17d1719b42b800028b',
+            'title': 'Weather Land',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/7ZQwPhFzRnOon0lC154m/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 8337
+          },
+          {
+            'id': '52d313a912ea3dcf84000024',
+            'title': 'Futura Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/GtpiSE2SpWyO5Xytsuz1/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 5256
+          },
+          {
+            'id': '53d9650e4b87266dc9000082',
+            'title': 'Weather - powered by The Weather Channel',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/nL8Rpn0Sr2xPvqnX0XVc/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 4609
+          },
+          {
+            'id': '535cf7f618c570bf05000023',
+            'title': 'Love Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/wUP4KTqgTmqoyIHsR6k8/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 4194
+          },
+          {
+            'id': '54f791b593d5fbffb1000090',
+            'title': 'Sketchy Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/1f1P4aoYTJm5pifableO/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 3439
+          },
+          {
+            'id': '547bd7a0fb079720950000a7',
+            'title': 'Minimalist Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/pGyFR0W9QWiVrrCzFKhZ/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2988
+          },
+          {
+            'id': '52dca032f9d8ec5031000068',
+            'title': 'Time\u0026Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/WoICJjzdQHSzfuxDdQVO/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2356
+          },
+          {
+            'id': '5599a73fe47bb388a7000056',
+            'title': 'Simple Weather',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/RXAUoSIaRpq3tj3hwGnU/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 2019
+          },
+          {
+            'id': '529eaee7d7894b8324000022',
+            'title': 'Weather',
+            'type': 'watchapp',
+            'image_url': 'https://assets.getpebble.com/api/file/TKQb98tDSJeO83j3oXbK/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1950
+          },
+          {
+            'id': '566dc3ab7929075b2e000042',
+            'title': 'WUnderful Analog (Weather)',
+            'type': 'watchface',
+            'image_url': 'https://assets.getpebble.com/api/file/U10bXt0DSfusEGiBKgcl/convert?cache=true\u0026fit=crop\u0026w=144\u0026h=168',
+            'thumbs_up': 1796
+          }
+        ]
+      }
+    }
   }
 }
 </script>

--- a/src/components/pages/Search.vue
+++ b/src/components/pages/Search.vue
@@ -62,7 +62,6 @@ export default {
         window.$.getJSON(this.backendUrl + '/dev/apps/search/' + encodeURIComponent(this.searchText), function (j, s) {
           if (s === 'success') {
             that.searchResults = j
-            console.log(that.searchResults)
           } else {
             console.error(s)
             console.error(j)

--- a/src/components/pages/Search.vue
+++ b/src/components/pages/Search.vue
@@ -2,11 +2,11 @@
   <div>
     <header>
       <div class=" title-card search">
-        <input type="text" placeholder="Search">
+        <input type="text" placeholder="Search" v-model="searchText" v-on:keyup.enter="search">
       </div>
     </header>
     <main class="apps container text-center">
-      <card-collection :showTop="false"></card-collection>
+      <card-collection :showTop="false" v-bind:cards="searchResults"></card-collection>
 
       <nav>
         <ul class="pagination">
@@ -42,6 +42,34 @@ export default {
   name: 'search',
   components: {
     CardCollection
+  },
+  props: {
+    backendUrl: ''
+  },
+  data: function () {
+    return {
+      searchText: '',
+      searchResults: {
+        cards: []
+      }
+    }
+  },
+  methods: {
+    search: function () {
+      if (this.searchText !== '') {
+        var that = this
+
+        window.$.getJSON(this.backendUrl + '/dev/apps/search/' + encodeURIComponent(this.searchText), function (j, s) {
+          if (s === 'success') {
+            that.searchResults = j
+            console.log(that.searchResults)
+          } else {
+            console.error(s)
+            console.error(j)
+          }
+        })
+      }
+    }
   }
 }
 </script>

--- a/src/components/pages/Settings.vue
+++ b/src/components/pages/Settings.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+	  <header>
+      <div class="title-card">
+        <h3>Pebble Type</h3>
+      </div>
+	  </header>
+    <main class="text-center">
+		  <form>
+			  <input type="radio" id="aplite" value="aplite" v-model="platform"> <label for="aplite">Pebble Original/Steel (aplite)</label><br />
+			  <input type="radio" id="basalt" value="basalt" v-model="platform"> <label for="basalt">Pebble Time Steel (basalt)</label><br />
+			  <input type="radio" id="chalk" value="chalk" v-model="platform"> <label for="chalk">Pebble Time Round (chalk)</label><br />
+			  <input type="radio" id="diorite" value="diorite" v-model="platform"> <label for="diorite">Pebble 2 (diorite)</label><br />
+		  </form>
+	  </main>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'settings',
+  data: function () {
+    return {
+      platform: window.localStorage.getItem('platform')
+    }
+  },
+  watch: {
+    platform: function (p) {
+      this.platform = p
+      window.localStorage.setItem('platform', p)
+    }
+  },
+  beforeMount: function () {
+    if (this.platform == null) {
+      this.platform = 'aplite'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+main {
+  margin-top: 40px;
+}
+</style>

--- a/src/components/pages/widgets/AppTitleBar.vue
+++ b/src/components/pages/widgets/AppTitleBar.vue
@@ -1,0 +1,108 @@
+<template>
+    <div class="card subsection-inverse card-inverse text-left p-3 app-title-bar">
+      <img class="app-icon" v-if="app.assets.appIcon != ''" v-bind:src="app.assets.appIcon" alt="My App">
+      <div class="title-author">
+        <h1 class="tile">{{ app.title }}</h1>
+        <h2 class="author">{{ app.author.name }}</h2>
+      </div>
+
+      <div class="app-button-container float-right">
+        <button type="button" class="btn btn-outline-secondary btn-thumbs-up">
+        <svg class="svg-icon icon-thumbs-up" width="25px" height="25px" viewBox="0 0 25 25">
+          <use xlink:href="#iconThumbsUp"></use>
+        </svg>
+
+        {{ app.thumbs_up }}
+        </button>
+        <a v-bind:href="'pebble://appstore/' + app.id" class="btn btn-outline-pebble btn-download">
+        <svg class="svg-icon icon-download" width="25px" height="25px" viewBox="0 0 25 25">
+          <use xlink:href="#iconDownload"></use>
+        </svg>
+        GET
+        </a>
+      </div>
+    </div>
+</template>
+
+<script>
+export default {
+  name: 'ScreenshotList',
+  props: ['app']
+}
+</script>
+
+<<style lang="scss">
+@import './static/css/_variables.scss';
+
+// Title bar displayed below app banner
+.app-title-bar {
+    padding-left: 68px !important;
+    img {
+        position: absolute;
+        border-radius: 4px;
+        width: 42px;
+        height: 42px;
+        left: 16px;
+    }
+    // Author name and app title text container
+    .title-author {
+      height: 42px;
+      margin-top: -3px;
+      margin-bottom: 3px;
+      display: inline-block;
+      h1 {
+        font-size: 19px;
+        line-height: 26px;
+        display: inline;
+        color: #fff;
+      }
+      h2 {
+        line-height: 16px;
+        font-size: 16px;
+        color: #c3c3c3;
+        margin: 0;
+      }
+
+      // Styles for small screens
+      @media screen and (max-width: 430px) {
+        h1 {
+          font-size: 15px;
+        }
+        h2 {
+          font-size: 12px;
+        }
+      }
+      @media screen and (max-width: 320px) {
+        h1 {
+          font-size: 12px;
+        }
+        h2 {
+          font-size: 10px;
+        }
+      }
+    }
+
+    // Set styles of buttons in the app-button-container (app-details and app-versions page)
+    .app-button-container {
+      margin-top: 2px;
+      margin-bottom: 2px;
+      .btn {
+        @media screen and (max-width: 430px) {
+          // styles for when screen smaller than 430px to avoid breaking all styles (they make things smaller)
+          margin-top: 3px;
+          font-size: 0.7rem;
+          padding: .5rem .5rem;
+        }
+
+        // Set thumbs up button styles
+        &.btn-thumbs-up {
+          // Styles for when it is in focus, hovered, or active
+          &:hover, &:active, &.active {
+            color: #333;
+            outline: none;
+          }
+        }
+      }
+    }
+}
+</style>

--- a/src/components/pages/widgets/CardCollection.vue
+++ b/src/components/pages/widgets/CardCollection.vue
@@ -4,10 +4,10 @@
       <h6 class="text-left">
         <div class="pebble">{{ elTitle }}</div>
       </h6>
-      <small><a class="text-right" href="#/featured">See All ></a></small>
+      <small><a class="text-right" href="/featured">See All ></a></small>
     </div>
     <div class="card-columns">
-      <single-card v-for="n in 8"></single-card>
+      <single-card v-for="card in cards.cards" v-bind:card="card"></single-card>
     </div>
   </section>
 </template>
@@ -25,6 +25,9 @@ export default {
     showTop: {
       type: Boolean,
       default: true
+    },
+    cards: {
+      cards: []
     }
   },
   components: {

--- a/src/components/pages/widgets/ScreenshotList.vue
+++ b/src/components/pages/widgets/ScreenshotList.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="screenshots dragscroll">
+    <div class="screenshot-spacer"></div>
+      <div class="screenshot" v-for="screenshot in getPlatform().screenshots">
+        <img v-bind:src="screenshot" alt="Screenshot" />
+      </div>
+      <!-- Screenshots -->
+    <div class="screenshot-spacer"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ScreenshotList',
+  props: ['platforms', 'clientPlatform'],
+  methods: {
+    getPlatform: function () {
+      var that = this
+      for (var i = 0; i < this.platforms.length; ++i) {
+        if (this.platforms[i].platform === that.clientPlatform && this.platforms[i].screenshots.length > 0) {
+          return this.platforms[i]
+        }
+      }
+
+      for (i = 0; i < this.platforms.length; ++i) {
+        if (this.platforms[i].screenshots.length > 0) {
+          return this.platforms[i]
+        }
+      }
+
+      return []
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import './static/css/_variables.scss';
+
+// Screenshots slider
+.screenshots {
+    max-width: 100%;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    display: flex;
+    margin-bottom: 40px;
+    -ms-overflow-style: none;
+    overflow: -moz-scrollbars-none;
+    &::-webkit-scrollbar {
+        background: transparent;
+        width: 0 !important;
+    }
+    img {
+        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+        margin-left: 20px;
+        margin-right: 20px;
+        margin-bottom: 5px;
+        margin-top: 5px;
+        user-drag: none;
+        user-select: none;
+        -moz-user-select: none;
+        -webkit-user-drag: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+    }
+    // This spacer is the one that centers the first screenshot
+    .screenshot-spacer {
+        width: calc(50vw - 92px);
+        height: 168px;
+        display: table;
+    }
+}
+
+</style>

--- a/src/components/pages/widgets/SingleCard.vue
+++ b/src/components/pages/widgets/SingleCard.vue
@@ -1,15 +1,15 @@
 <template>
-  <a href="#/app-details">
+  <a v-bind:href="'/app-details/' + card.id">
   <div class="card">
-    <img class="card-img-top" src="https://assets.getpebble.com/api/file/SAPbwhJzShmep72rvxTQ/convert?cache=true&fit=crop&w=144&h=168" alt="My Watchface">
+    <img class="card-img-top" v-bind:src="card.image_url" alt="App Icon">
     <div class="card-block text-xs-center">
-      <h4 class="card-title">My Watchface</h4>
+      <h6 class="card-title">{{ card.title }}</h6>
       <p class="card-text">
         <small class="text-muted">
           <svg class="svg-icon icon-inverted-thumbs-up" width="16px" height="16px" viewBox="0 0 25 25">
             <use xlink:href="#iconThumbsUp"></use>
           </svg>
-          14.5K
+          {{ card.thumbs_up }}
         </small>
       </p>
     </div>
@@ -19,7 +19,16 @@
 
 <script>
 export default {
-  name: 'single-card'
+  name: 'single-card',
+  props: {
+    card: {
+      id: '',
+      title: '',
+      type: '',
+      image_url: '',
+      thumbs_up: 0
+    }
+  }
 }
 </script>
 
@@ -43,6 +52,10 @@ export default {
 
         .card {
             max-width: 170px;
+
+            .card-title {
+              word-wrap: break-word;
+            }
 
             // Make it smaller on small screens
             @media screen and (max-width: map-get($grid-breakpoints, sm)) {

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,15 @@ import AppDetails from './components/pages/AppDetails'
 import AppVersions from './components/pages/AppVersions'
 import Author from './components/pages/Author'
 import Search from './components/pages/Search'
+import Settings from './components/pages/Settings'
 import Error from './components/pages/Error'
+
+Vue.filter('formatDate', function (d) {
+  var date = new Date(d)
+  if (date) {
+    return date.getFullYear() + '-' + ((date.getMonth() + 1) >= 10 ? (date.getMonth() + 1) : ('0' + (date.getMonth() + 1))) + '-' + (date.getDate() >= 10 ? date.getDate() : ('0' + date.getDate()))
+  }
+})
 
 Vue.use(VueRouter)
 
@@ -21,16 +29,17 @@ const routes = [
   {path: '/apps', component: AppList},
   {path: '/featured', component: Featured},
   {path: '/category', component: Category},
-  {path: '/app-details', component: AppDetails},
-  {path: '/app-versions', component: AppVersions},
+  {path: '/app-details/:id', component: AppDetails},
+  {path: '/app-versions/:id', component: AppVersions},
   {path: '/author', component: Author},
   {path: '/search', component: Search},
-  {path: '/error', component: Error}
+  {path: '/settings', component: Settings},
+  {path: '*', component: Error}
 ]
 
 const router = new VueRouter({
-  routes
-  // mode: 'history'
+  routes,
+  mode: 'history'
 })
 
 new Vue({

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import AppDetails from './components/pages/AppDetails'
 import AppVersions from './components/pages/AppVersions'
 import Author from './components/pages/Author'
 import Search from './components/pages/Search'
+import Collection from './components/pages/Collection'
 import Settings from './components/pages/Settings'
 import Error from './components/pages/Error'
 
@@ -33,6 +34,7 @@ const routes = [
   {path: '/app-versions/:id', component: AppVersions},
   {path: '/author', component: Author},
   {path: '/search', component: Search},
+  {path: '/collection/:id', component: Collection},
   {path: '/settings', component: Settings},
   {path: '*', component: Error}
 ]


### PR DESCRIPTION
This PR adds full (albeit improvable) support for `/app-details`, `/app-versions`, `/collection`, and `/search`, as well a `/settings` page to select your watch (which will have to be improved at some point in the future, as it's only 4 ugly radios right now).

`/` and `/featured` only contain placeholders for now. `/author` is to be implemented (the API endpoint doesn't exist yet).

Please expect the code to be somewhat messy; I picked up Vue for the occasion, and I'd like some input on what to fix before this is merged.

Please note that you will need to run the latest [backend](https://github.com/pebble-dev/rebblestore-api) with command line option `--store-url=http://localhost:8081` (to correctly set the Access-Control-Allow-Origin header).