### PR TITLE
Make _variables.scss global

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -60,7 +60,14 @@ exports.cssLoaders = function (options) {
     postcss: generateLoaders(),
     less: generateLoaders('less'),
     sass: generateLoaders('sass', { indentedSyntax: true }),
-    scss: generateLoaders('sass'),
+    scss: generateLoaders('sass').concat(
+      {
+        loader: 'sass-resources-loader',
+        options: {
+          resources:  [path.resolve(__dirname, '../static/css/_variables.scss')]
+        }
+      }
+    ),
     stylus: generateLoaders('stylus'),
     styl: generateLoaders('stylus')
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3232,6 +3232,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -6248,14 +6257,20 @@
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "dev": true,
       "requires": {
+        "decompress-response": "3.3.0",
         "duplexer3": "0.1.4",
         "get-stream": "3.0.0",
         "is-plain-obj": "1.1.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
+        "isurl": "1.0.0",
         "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.1",
         "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1"
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -6459,6 +6474,21 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+      "integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -7167,6 +7197,12 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-odd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
@@ -7463,6 +7499,16 @@
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
         "semver": "5.5.0"
+      }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "js-base64": {
@@ -8411,6 +8457,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
       "dev": true
     },
     "minimalistic-assert": {
@@ -9421,6 +9473,12 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "p-cancelable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -9450,6 +9508,15 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+      "dev": true,
+      "requires": {
+        "p-finally": "1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -11531,6 +11598,53 @@
         }
       }
     },
+    "sass-resources-loader": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sass-resources-loader/-/sass-resources-loader-1.3.2.tgz",
+      "integrity": "sha512-7U55FKFMD7I//l/Ijm3GrqjOBw66D6NbGrwiD/uZ/S85fOB/4a3kibsaRWYkbO9t1aQPZz1V/69C5k2B1nS1bw==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "chalk": "1.1.3",
+        "glob": "7.1.2",
+        "loader-utils": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -13214,6 +13328,21 @@
           "dev": true
         }
       }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
     },
     "use": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "postcss-url": "^7.2.1",
     "rimraf": "^2.6.0",
     "sass-loader": "^6.0.6",
+    "sass-resources-loader": "^1.3.2",
     "selenium-server": "^3.0.1",
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -88,8 +88,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
 // Select the dark translucent navbar
 .navbar-dark.bg-dark.translucent {
   .navbar-container {

--- a/src/components/PageFooter.vue
+++ b/src/components/PageFooter.vue
@@ -23,8 +23,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
 // _footer.scss
 // Footer styles
 

--- a/src/components/SvgContainer.vue
+++ b/src/components/SvgContainer.vue
@@ -106,7 +106,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './static/css/_variables.scss';
 // Remember that font-awesome is included in the projects
 
   #svgContainer {

--- a/src/components/pages/AppVersions.vue
+++ b/src/components/pages/AppVersions.vue
@@ -47,8 +47,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
 // App details container (below screenshots)
 .app-details {
     &:last-of-type {

--- a/src/components/pages/AppView.vue
+++ b/src/components/pages/AppView.vue
@@ -83,8 +83,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './static/css/_variables.scss';
-
 // _app-details.scss
 // App details page styles
 

--- a/src/components/pages/Error.vue
+++ b/src/components/pages/Error.vue
@@ -62,8 +62,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
 // _error.scss
 // Error page styles
 

--- a/src/components/pages/widgets/AppTitleBar.vue
+++ b/src/components/pages/widgets/AppTitleBar.vue
@@ -34,8 +34,6 @@ export default {
 </script>
 
 <style lang="scss">
-@import './static/css/_variables.scss';
-
 // Title bar displayed below app banner
 .app-title-bar-cont {
   padding-top: 15px;

--- a/src/components/pages/widgets/CardCollection.vue
+++ b/src/components/pages/widgets/CardCollection.vue
@@ -41,8 +41,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
     // Each group of cards is supposed to be a section
     section {
         // Add a margin to the bottom of each section

--- a/src/components/pages/widgets/SingleCard.vue
+++ b/src/components/pages/widgets/SingleCard.vue
@@ -59,8 +59,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
-
   div.loading {
     .loader {
       display: block;

--- a/src/components/pages/widgets/SingleScreenshot.vue
+++ b/src/components/pages/widgets/SingleScreenshot.vue
@@ -35,7 +35,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import './static/css/_variables.scss';
 .loader {
   width: 144px;
   height: 168px;


### PR DESCRIPTION
Issue #67 

- removed @imports in all components
- made _variable.scss global, so every component which has a `<style lang="scss">` automatically includes it.
 
> It is recommended to only include variables, mixins, etc. in this file, to prevent duplicated css in your final, compiled files. [[Loading a global settings file](https://github.com/westwick/vue-loader/blob/7aa27c062e8cc2960fff3d0c22355a88ca0073a7/docs/en/configurations/pre-processors.md)]