### PR TITLE
Fix empty string in search error

### DIFF
--- a/src/components/pages/Search.vue
+++ b/src/components/pages/Search.vue
@@ -103,6 +103,10 @@ export default {
   watch: {
     'rebbleSearch.query' (value) {
       if (this.$router.params === undefined) {
+        if (value === '') {
+          this.$router.push({path: `/${this.type}/search`})
+          return
+        }
         this.$router.push({ path: `/${this.type}/search/${value}/${this.page}` })
       } else {
         this.$router.push({


### PR DESCRIPTION
Makes it so when you have an empty string, goes back to main empty search page instead of 404ing.