### PR TITLE
Hide website link area when website link is null

### DIFF
--- a/src/components/pages/AppDetails.vue
+++ b/src/components/pages/AppDetails.vue
@@ -31,7 +31,7 @@
           Version Information <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
         </div>
       </router-link>
-      <a v-if="app.website != ''" v-on:click="openExternal(app.website)" class="app-button">
+      <a v-if="app.website != null" v-on:click="openExternal(app.website)" class="app-button">
         <div>
           Website Link <i class="fa fa-angle-right float-right" aria-hidden="true"></i>
         </div>


### PR DESCRIPTION
Fixes #165 

This could work if most of the records in the DB have website links as `null` and not `''` (empty string; what the current check is for).

Or we could make it a check for both.

This is a screenshot showing the Tennis app mentioned in the linked issue. It now doesn't show the website link because it is `null`.
<img width="449" alt="Screen Shot 2020-09-01 at 10 59 44 AM" src="https://user-images.githubusercontent.com/8609429/91889297-74cfe600-ec42-11ea-8d7d-1c0d1d247fbf.png">