### PR TITLE
Update readme with newer backend api info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Rebble Store for pebble
+
 The Rebble Store is a Pebble Appstore replacement.
 
 If you want to contribute join us on the [Pebble Dev Discord server](http://discord.gg/aRUAYFN), then head to `#appstore`.
@@ -8,10 +9,10 @@ This is the Rebble replacement for the Pebble app store. This project is under a
 This project is built with [VueJS 2](https://vuejs.org/), with webpack scripts included for debugging, hot-reload, and production builds. More information on the Vue webpack build scripts can be found [here](https://github.com/vuejs-templates/webpack).
 
 ## Backend/API
-This project has a separate backend/api with a Python option and a GoLang option, for now the main one with all the issues is Golang.
-- **GoLang:** https://github.com/pebble-dev/rebblestore-api
 
-The Python backend has been deprecated.
+This project has a separate backend/api that's currently written in Python. It can be found [here](https://github.com/pebble-dev/rebble-appstore-api).
+
+It's not necessary to run the API locally unless also developing for the API. The frontend points to the production API by default.
 
 ## Installing
 


### PR DESCRIPTION
I thought the readme was a little confusing about the backend API stuff. It was hard to understand that running it isn't necessary for local dev.

Open to any more edits of course.