### PR TITLE
App bindings fix

### DIFF
--- a/src/components/pages/widgets/GetAppButton.vue
+++ b/src/components/pages/widgets/GetAppButton.vue
@@ -89,7 +89,7 @@ export default {
       this.add_app()
     },
     check_supported () {
-      this.hardwareSupported = this.app.compatibility && this.app.compatibility[this.$store.state.userParameters.hardware] && this.app.compatibility[this.$store.state.userParameters.hardware].supported === true
+      this.hardwareSupported = this.$store.state.userParameters.hardware === 'all' || (this.app.compatibility && this.app.compatibility[this.$store.state.userParameters.hardware] !== undefined && this.app.compatibility[this.$store.state.userParameters.hardware].supported === true)
       this.platformSupported = this.$store.state.userParameters.platform === 'all' || this.app.compatibility[this.$store.state.userParameters.platform].supported
     },
     create_permissions () {


### PR DESCRIPTION
#161 

I'm still trying to figure out why when you open a Pebble Link from safari it opens a page with url `$$id$$` instead of the actual id.