### PR TITLE
Update the developer portal links to point to rebble.io/submit

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -143,7 +143,7 @@
   <footer>
     <p>© 2016 Rebble · <a href="#">Contact Us</a> · <a href="#">Terms</a>
     </p>
-    <a class="pull-right" href="#">Developer Portal</a>
+    <a class="pull-right" href="https://rebble.io/submit/">Developer Portal</a>
   </footer>
   <!-- jQuery first, then Tether, then Bootstrap JS. -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>

--- a/src/components/PageFooter.vue
+++ b/src/components/PageFooter.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="main">
         <p>© {{ new Date().getFullYear() }} Rebble · <a v-on:click="openExternal($store.state.config.contactLink)">Contact Us</a> · <a  v-on:click="openExternal($store.state.config.tosLink)">Terms</a></p>
-        <a class="pull-right" v-on:click="openExternal('#')">Developer Portal</a>
+        <a class="pull-right" v-on:click="openExternal('$store.state.config.devPortalLink')">Developer Portal</a>
     </div>
   </footer>
 </template>

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -4,6 +4,7 @@ export default {
     backendUrl: 'https://appstore-api.rebble.io/api/v1',
     devPortalBackendUrl: 'https://appstore-api.rebble.io/api/v0',
     tosLink: 'https://rebble.io/tos/',
+    devPortalLink: 'https://rebble.io/submit/',
     contactLink: '',
     accessToken: null
   }


### PR DESCRIPTION
I noticed the developer portal links weren't set, so I've updated them to point to rebble.io/submit!

I copied the login from the tosLink, so the dev portal link is defined in the config, but hardcoded in the 404 page.